### PR TITLE
Fix xcolor option passing

### DIFF
--- a/rebuttal.sty
+++ b/rebuttal.sty
@@ -18,7 +18,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{rebuttal}[2021/03/08 v0.1 Markup for rebuttal letters]
 
-\PassOptionsToPackage{dvipsnames,svgnames,x11names}{xcolor}
 
 \RequirePackage{calc}
 \RequirePackage{environ}
@@ -29,7 +28,7 @@
 \RequirePackage{tikz}
 \RequirePackage{todonotes}
 \RequirePackage{ulem}
-\RequirePackage{xcolor}
+\RequirePackage[dvipsnames,svgnames,x11names]{xcolor}
 \RequirePackage{xstring}
 
 \AtEndPreamble{


### PR DESCRIPTION
When importing the rebuttal package into existing tex files, the xcolor options are not resolved properly (same for overleaf environments). Replacing the `\PassOptionsToPackage` call with `\RequirePackage` options solves the issue. 